### PR TITLE
Cannot create colour maps where the opacity or color plane only has one point

### DIFF
--- a/lib/gradient/map.rb
+++ b/lib/gradient/map.rb
@@ -44,8 +44,8 @@ module Gradient
 
     private def previous_and_next_in(bucket, point)
       groups = bucket.group_by { |p| point_group(p, point) }
-      a = groups.fetch(:same) { groups.fetch(:less) }.max { |p| p.location }
-      b = groups.fetch(:same) { groups.fetch(:more) }.min { |p| p.location }
+      a = groups.fetch(:same) { groups.fetch(:less) { groups.fetch(:more) } }.max { |p| p.location }
+      b = groups.fetch(:same) { groups.fetch(:more) { groups.fetch(:less) } }.min { |p| p.location }
       return a, b
     end
 

--- a/lib/gradient/map.rb
+++ b/lib/gradient/map.rb
@@ -5,6 +5,7 @@ module Gradient
 
     def initialize(color_points=[], opacity_points=[])
       color_points << Gradient::ColorPoint.new(0, Color::RGB.new(255, 255, 255)) if color_points.empty?
+      opacity_points << Gradient::OpacityPoint.new(0, 1) if opacity_points.empty?
       @color_points = sort_points(Array(color_points))
       @opacity_points = sort_points(Array(opacity_points))
       @all_points = sort_points(@color_points + @opacity_points)

--- a/lib/gradient/map.rb
+++ b/lib/gradient/map.rb
@@ -4,6 +4,7 @@ module Gradient
     attr_reader :color_points, :opacity_points, :points
 
     def initialize(color_points=[], opacity_points=[])
+      color_points << Gradient::ColorPoint.new(0, Color::RGB.new(255, 255, 255)) if color_points.empty?
       @color_points = sort_points(Array(color_points))
       @opacity_points = sort_points(Array(opacity_points))
       @all_points = sort_points(@color_points + @opacity_points)

--- a/spec/gradient/map_spec.rb
+++ b/spec/gradient/map_spec.rb
@@ -123,6 +123,19 @@ RSpec.describe Gradient::Map do
       expect(gradient.points.last.opacity).to eq 1
     end
 
+    it "reconciles when there are no opacity points" do
+      white = Gradient::ColorPoint.new(0, Color::RGB.new(255, 255, 255))
+      black = Gradient::ColorPoint.new(1, Color::RGB.new(0, 0, 0))
+      color_points = [white, black]
+
+      gradient = Gradient::Map.new(color_points, [])
+      expect(gradient.points.size).to eq 2
+      expect(gradient.points.first.color).to eq white.color
+      expect(gradient.points.first.opacity).to eq 1
+      expect(gradient.points.last.color).to eq black.color
+      expect(gradient.points.last.opacity).to eq 1
+    end
+
     it "reconciles when there are no color points" do
       opacity_points = [
         Gradient::OpacityPoint.new(0, 0),

--- a/spec/gradient/map_spec.rb
+++ b/spec/gradient/map_spec.rb
@@ -123,6 +123,20 @@ RSpec.describe Gradient::Map do
       expect(gradient.points.last.opacity).to eq 1
     end
 
+    it "reconciles when there are no color points" do
+      opacity_points = [
+        Gradient::OpacityPoint.new(0, 0),
+        Gradient::OpacityPoint.new(1, 1),
+      ]
+
+      gradient = Gradient::Map.new([], opacity_points)
+      expect(gradient.points.size).to eq 2
+      expect(gradient.points.first.color).to eq Color::RGB.new(255, 255, 255)
+      expect(gradient.points.first.opacity).to eq 0
+      expect(gradient.points.last.color).to eq Color::RGB.new(255, 255, 255)
+      expect(gradient.points.last.opacity).to eq 1
+    end
+
   end
 
 end

--- a/spec/gradient/map_spec.rb
+++ b/spec/gradient/map_spec.rb
@@ -91,6 +91,38 @@ RSpec.describe Gradient::Map do
       expect(gradient.points.last.color).to eq black.color
       expect(gradient.points.last.opacity).to eq 1
     end
+
+    it "reconciles there only being one opacity point" do
+      white = Gradient::ColorPoint.new(0, Color::RGB.new(255, 255, 255))
+      black = Gradient::ColorPoint.new(1, Color::RGB.new(0, 0, 0))
+      color_points = [white, black]
+
+      opacity_points = [
+        Gradient::OpacityPoint.new(1, 1),
+      ]
+
+      gradient = Gradient::Map.new(color_points, opacity_points)
+      expect(gradient.points.first.color).to eq white.color
+      expect(gradient.points.first.opacity).to eq 1
+      expect(gradient.points.last.color).to eq black.color
+      expect(gradient.points.last.opacity).to eq 1
+    end
+
+    it "reconciles there only being one color point" do
+      white = Gradient::ColorPoint.new(0, Color::RGB.new(255, 255, 255))
+
+      opacity_points = [
+        Gradient::OpacityPoint.new(0, 0),
+        Gradient::OpacityPoint.new(1, 1),
+      ]
+
+      gradient = Gradient::Map.new([white], opacity_points)
+      expect(gradient.points.first.color).to eq white.color
+      expect(gradient.points.first.opacity).to eq 0
+      expect(gradient.points.last.color).to eq white.color
+      expect(gradient.points.last.opacity).to eq 1
+    end
+
   end
 
 end


### PR DESCRIPTION
Proved this by the failing test case. Cannot be merged until it's properly fixed.
