### PR TITLE
fix: ensure ruby 2.7 compatibility by including scanf gem

### DIFF
--- a/gradient.gemspec
+++ b/gradient.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "color", "~> 1.8"
   spec.add_dependency 'nokogiri', '~> 1.6'
+  spec.add_dependency 'scanf', '~> 1.0'
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
fix for #7 

* scanf was excluded from the standard libary as of ruby 2.7
* see https://rubyreferences.github.io/rubychanges/2.7.html#libraries-excluded-from-the-standard-library
* include the official scanf gem in gemspec